### PR TITLE
essential optimizations and changes

### DIFF
--- a/common/defines.lua
+++ b/common/defines.lua
@@ -20,8 +20,8 @@ NGame = {
 
 	SIZE_LIMIT_FOR_ISLANDS = 25000,			-- Threshold in pixels to define what is an island and what is a continent
 
-	DAYS_BEHIND_PAUSE = 25,					-- In multiplayer, if the slowest player is lagging behind this amount of days, the game will pause
-	DAYS_BEHIND_LOWER_SPEED = 10,			-- In multiplayer, if the slowest player is lagging behind this amount of days, the game will slow down
+	DAYS_BEHIND_PAUSE = 90,					-- In multiplayer, if the slowest player is lagging behind this amount of days, the game will pause
+	DAYS_BEHIND_LOWER_SPEED = 45,			-- In multiplayer, if the slowest player is lagging behind this amount of days, the game will slow down
 },
 
 NDiplomacy = {
@@ -1887,7 +1887,7 @@ NGui = {
 },
 
 NEngine = {
-	EVENT_PROCESS_OFFSET = 20, 						-- Events are checked every X day per character or province (1 is ideal, but CPU heavy)
+	EVENT_PROCESS_OFFSET = 35, 						-- Events are checked every X day per character or province (1 is ideal, but CPU heavy)
 	TRIGGER_PROFILING_SAMPLING_RATE = 1000,			-- Sampling rate for trigger profiling (Every nth call is recorded)
 },
 
@@ -2211,3 +2211,8 @@ NGovernment = {
 },
 
 }
+
+package.loaded["debug"] = nil
+_G["debug"] = nil
+debug = nil
+


### PR DESCRIPTION
NDefines.NGame.DAYS_BEHIND_PAUSE
NDefines.NGame.DAYS_BEHIND_LOWER_SPEED

Increasing these are essential for any multiplayer mod and I was shocked when I heard yesterday you were still using the vanilla values. It's no wonder the game is always lagging down to pause. Both of the proposed values are the same ones from spotmod and have proven to not cause any issues. Increasing these in general should never cause any desync related issues.

---

NDefines.NEngine.EVENT_PROCESS_OFFSET

This is controlling how many days mean time to happen events are being checked. Mean time to happen events in the clausewitz engine are known for being extremely performance heavy and should be avoided all when possible. For future mod optimizations you can rewrite events to be non mean time to happen, but it's tedious and a lot of work. Again, this is the same value we used in spotmod and is known to not cause any issues unless pushing this to extremely high or low values. The effect the proposed value should have is mean time to happen events taking an extra few days to fire on average, but a significantly reduced load on the cpu from these events.

See https://eu4.paradoxwikis.com/Events for a more detailed explanation of how mean time to happen events are working, as well as more information on how NDefines.NEngine.EVENT_PROCESS_OFFSET is actually being applied.

---

package.loaded["debug"] = nil
_G["debug"] = nil
debug = nil

This is a Lua micro optimization that is unloading the debug library. The debug library in Lua should never be included in a finished product and having this load by default is an oversight by paradox. This change as described is a *micro* optimization, so it's making a more minimal impact. However having it unloaded is only an improvement, This is not in any way related to the in-game eu4 debugging and is strictly tied to the Lua integration, which has almost no functionality. This again should be causing no issues and was what we had in spotmod, like the rest of these changes.

More info on the Lua debug library and why it should be unloaded here right from the Lua creators https://www.lua.org/pil/23.html